### PR TITLE
Enable testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 dev_data
-.vscode
 www
 *_templ.go
+
+.DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ www
 
 .DS_Store
 .vscode
+.idea/

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:bullseye
+
+# ================================
+# ===   Update Dependencies    ===
+# ================================
+RUN apt-get update && apt-get install -y \
+  curl \
+  git \
+  build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+# ================================
+# === Install Go, Node and NPM ===
+# ================================
+ENV GO_VERSION 1.21.0
+RUN curl -LO "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+  && tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz" \
+  && rm "go${GO_VERSION}.linux-amd64.tar.gz"
+ENV PATH $PATH:/usr/local/go/bin
+
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+  && apt-get install -y nodejs \
+  && npm install -g npm@latest
+
+# Verify installations
+RUN node -v && npm -v && go version
+
+
+# ================================
+# === Setup passwordless sudo  ===
+# ================================
+RUN useradd -m appuser -G sudo && \
+  echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER appuser
+
+# ================================
+# ===      Set up project      ===
+# ================================
+WORKDIR /home/appuser/app
+ENV CGO_ENABLED=0
+
+COPY go.mod go.sum ./
+RUN go mod download 
+
+COPY . .
+
+# RUN npm install

--- a/docker/tests/docker-compose.yml
+++ b/docker/tests/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: docker/tests/Dockerfile
+    environment:
+      - DSN="host=db port=15432 user=testuser password=testpass dbname=testdb sslmode=disable"
+      - PORT="0.0.0.0:18080"
+    ports:
+      - "18080:18080"
+    depends_on:
+      - db
+    command: ["go", "test", "-tags=integration", "."]
+  db:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpass
+      POSTGRES_DB: testdb
+    ports:
+      - "15432:15432"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/a-h/templ v0.2.513 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.9.1 // indirect
@@ -28,6 +29,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mozillazg/go-unidecode v0.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
@@ -61,9 +62,11 @@ github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4A
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -72,6 +75,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=

--- a/initializers/db.go
+++ b/initializers/db.go
@@ -1,24 +1,51 @@
 package initializers
 
 import (
+	"fmt"
+	"log"
 	"os"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 	"marxists.org/models"
 )
 
 var DB *gorm.DB
 
-func ConnectDB() {
+func ConnectDB() error {
 	dsn := os.Getenv("DSN")
-	var err error
-	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		panic("failed to connect database")
+	if dsn == "" {
+		return fmt.Errorf("DSN is not set!")
 	}
 
-	DB.AutoMigrate(&models.Author{}, &models.Glossary{}, &models.Work{},
-		&models.Collection{}, &models.Movement{}) //, &models.AuthorWork{})
-}
+	logger := logger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		logger.Config{
+			SlowThreshold: time.Second,
+			LogLevel:      logger.Silent,
+			Colorful:      true,
+		},
+	)
 
+	config := &gorm.Config{
+		PrepareStmt: true,
+		Logger:      logger,
+	}
+
+	var err error
+
+	DB, err = gorm.Open(postgres.Open(dsn), config)
+	if err != nil {
+		return fmt.Errorf("Failed to connect to the database: %w", err)
+	}
+
+	err = DB.AutoMigrate(&models.Author{}, &models.Glossary{}, &models.Work{},
+		&models.Collection{}, &models.Movement{}) //, &models.AuthorWork{})
+	if err != nil {
+		return fmt.Errorf("Failed to auto-migrate database models: %w", err)
+	}
+
+	return nil
+}

--- a/initializers/db.go
+++ b/initializers/db.go
@@ -17,10 +17,10 @@ var DB *gorm.DB
 func ConnectDB() error {
 	dsn := os.Getenv("DSN")
 	if dsn == "" {
-		return fmt.Errorf("DSN is not set!")
+		return fmt.Errorf("DSN is not set")
 	}
 
-	logger := logger.New(
+	loggerConfig := logger.New(
 		log.New(os.Stdout, "\r\n", log.LstdFlags),
 		logger.Config{
 			SlowThreshold: time.Second,
@@ -31,20 +31,20 @@ func ConnectDB() error {
 
 	config := &gorm.Config{
 		PrepareStmt: true,
-		Logger:      logger,
+		Logger:      loggerConfig,
 	}
 
 	var err error
 
 	DB, err = gorm.Open(postgres.Open(dsn), config)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to the database: %w", err)
+		return fmt.Errorf("failed to connect to the database: %w", err)
 	}
 
 	err = DB.AutoMigrate(&models.Author{}, &models.Glossary{}, &models.Work{},
 		&models.Collection{}, &models.Movement{}) //, &models.AuthorWork{})
 	if err != nil {
-		return fmt.Errorf("Failed to auto-migrate database models: %w", err)
+		return fmt.Errorf("failed to auto-migrate database models: %w", err)
 	}
 
 	return nil

--- a/initializers/env.go
+++ b/initializers/env.go
@@ -1,14 +1,15 @@
 package initializers
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/joho/godotenv"
 )
 
-func LoadEnv() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
+func LoadEnv(envFilePath string) error {
+	if err := godotenv.Load(envFilePath); err != nil {
+		return fmt.Errorf("Error loading .env file: %v", err)
 	}
+
+	return nil
 }

--- a/initializers/env_test.go
+++ b/initializers/env_test.go
@@ -1,0 +1,35 @@
+package initializers
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadEnv_Successful(t *testing.T) {
+	// Arrange
+	file, err := os.CreateTemp("", "*.env")
+
+	env := []byte("PROBLEM=\"capitalism\"\nSOLUTION=\"revolution!\"\n")
+	file.Write(env)
+	file.Close()
+	defer os.Remove(file.Name())
+
+	// Act
+	err = LoadEnv(file.Name())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, "capitalism", os.Getenv("PROBLEM"))
+	assert.Equal(t, "revolution!", os.Getenv("SOLUTION"))
+}
+
+func TestLoadEnv_Failure_FileDoesntExist(t *testing.T) {
+	// Act
+	err := LoadEnv("fake.env")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, "Error loading .env file: open fake.env: no such file or directory", err.Error())
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -12,9 +13,15 @@ import (
 var DB *gorm.DB
 
 func init() {
-	initializers.LoadEnv()
-	initializers.ConnectDB()
-	DB = initializers.DB
+	var err error
+
+	if initializers.LoadEnv(".env"); err != nil {
+		log.Fatalf("Failed environment initialization: %v", err)
+	}
+
+	if initializers.ConnectDB(); err != nil {
+		log.Fatalf("Failed database initialization: %v", err)
+	}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 var DB *gorm.DB
 
-func init() {
+func Init() {
 	var err error
 
 	if initializers.LoadEnv(".env"); err != nil {
@@ -24,10 +24,12 @@ func init() {
 	}
 }
 
-func main() {
+func StartServer() {
 	router := gin.Default()
-
 	Routes(router)
-
 	router.Run(os.Getenv("PORT"))
+}
+
+func main() {
+	StartServer()
 }

--- a/main.go
+++ b/main.go
@@ -15,11 +15,11 @@ var DB *gorm.DB
 func Init() {
 	var err error
 
-	if initializers.LoadEnv(".env"); err != nil {
+	if err = initializers.LoadEnv("./.env"); err != nil {
 		log.Fatalf("Failed environment initialization: %v", err)
 	}
 
-	if initializers.ConnectDB(); err != nil {
+	if err = initializers.ConnectDB(); err != nil {
 		log.Fatalf("Failed database initialization: %v", err)
 	}
 }
@@ -27,9 +27,13 @@ func Init() {
 func StartServer() {
 	router := gin.Default()
 	Routes(router)
-	router.Run(os.Getenv("PORT"))
+
+	if err := router.Run(os.Getenv("PORT")); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
 }
 
 func main() {
+	Init()
 	StartServer()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+// +build integration
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var serverStarted bool
+
+func TestMain(m *testing.M) {
+	if !serverStarted {
+		StartServer()
+		duration, _ := time.ParseDuration("5s")
+		time.Sleep(duration)
+	}
+
+	exitCode := m.Run()
+
+	os.Exit(exitCode)
+}
+
+func TestE2E_GetOneAuthor(t *testing.T) {
+	assert.True(t, false)
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "tw": "npx tailwindcss -o ./www/styles/style.css --watch",
     "go": "templ generate && go run *.go",
-    "start": "npm run tw & npm run go"
+    "start": "npm run tw & npm run go",
+    "test-int": "docker-compose -f ./docker/tests/docker-compose.yml up --build"
   }
 }

--- a/routes.go
+++ b/routes.go
@@ -1,17 +1,13 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/gin-gonic/gin"
 	"marxists.org/controllers"
 	"marxists.org/models/repository"
 )
 
 func Routes(router *gin.Engine) {
-	fmt.Println("DB:", DB, *DB)
 	router.StaticFile("style.css", "./www/styles/style.css")
-	//router.LoadHTMLGlob("views/*.gohtml")
 
 	authorController := controllers.AuthorController{Repo: repository.AuthorRepository{Db: DB}}
 	searchController := controllers.SearchController{Repo: repository.SearchRepository{Db: DB}}


### PR DESCRIPTION
We want to ensure stable service when we actually deploy this live. We should hit the ground running with tests even if it does slow us down somewhat. I propose full end-to-end user-based tests rather than unit tests, so that we can cover things such as raw DB queries.

- [x] Set up secure Docker environment for running E2E tests with Go and Node.
- [ ] Get `go test -tags=integration .` to run properly.
- [ ] Create a few useful tests.   